### PR TITLE
Update Instructions

### DIFF
--- a/manuals/Logic/Instructions
+++ b/manuals/Logic/Instructions
@@ -35,7 +35,7 @@ The following are equivalent:
 	[royal]set[] [coral]egg[] [stat]"egg yum yum"[]
 	[royal]print[] [stat]egg[]
 and
-	[royal]print[] [stat]"egg yum yum"[]
+	[royal]printflush[] [stat]"egg yum yum"[]
 
 Sub-instructions can never be passed from a variable.
 


### PR DESCRIPTION
Seemed to leave out the difference between print and printflush. Fixed.